### PR TITLE
chore: request new repositories

### DIFF
--- a/otterdog/eclipse-dataspacetck.jsonnet
+++ b/otterdog/eclipse-dataspacetck.jsonnet
@@ -49,7 +49,8 @@ orgs.newOrg('eclipse-dataspacetck') {
     },
   ],
   _repositories+:: [
-    newRepo('cvf') {
+    newRepo('dsp-tck') {
+      aliases: ['cvf'],
       description: "Compliance Verification Framework",
     },
     newRepo('dcp-tck'){

--- a/otterdog/eclipse-dataspacetck.jsonnet
+++ b/otterdog/eclipse-dataspacetck.jsonnet
@@ -7,6 +7,18 @@ local newRepo(repoName) = orgs.newRepo(repoName) {
       dependabot_alerts_enabled: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
+      has_discussions: true,
+      has_wiki: false,
+      allow_auto_merge: true,
+      dependabot_security_updates_enabled: true,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
 };
 
 orgs.newOrg('eclipse-dataspacetck') {
@@ -39,75 +51,15 @@ orgs.newOrg('eclipse-dataspacetck') {
   _repositories+:: [
     newRepo('cvf') {
       description: "Compliance Verification Framework",
-      has_discussions: true,
-      has_wiki: false,
-      allow_auto_merge: true,
-      allow_merge_commit: true,
-      private_vulnerability_reporting_enabled: true,
-      dependabot_alerts_enabled: true,
-      dependabot_security_updates_enabled: true,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          required_approving_review_count: 1,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
     },
     newRepo('dcp-tck'){
-      description: "Technology Compatibility Kit for the Decentralized Claims Protocol",
-      has_discussions: true,
-      has_wiki: false,
-      allow_auto_merge: true,
-      allow_merge_commit: true,
-      private_vulnerability_reporting_enabled: true,
-      dependabot_alerts_enabled: true,
-      dependabot_security_updates_enabled: true,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          required_approving_review_count: 1,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
+      description: "Technology Compatibility Kit for the Decentralized Claims Protocol"
     },
     newRepo('tck-common'){
-      description: "Shared code for all Technology Compatibility Kits and other projects",
-      has_discussions: true,
-      has_wiki: false,
-      allow_auto_merge: true,
-      allow_merge_commit: true,
-      private_vulnerability_reporting_enabled: true,
-      dependabot_alerts_enabled: true,
-      dependabot_security_updates_enabled: true,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          required_approving_review_count: 1,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
+      description: "Shared code for all Technology Compatibility Kits and other projects"
     },
     newRepo('tck-build'){
-      description: "Gradle Build customizations for the Technology Compatibility Kits",
-      has_discussions: true,
-      has_wiki: false,
-      allow_auto_merge: true,
-      allow_merge_commit: true,
-      private_vulnerability_reporting_enabled: true,
-      dependabot_alerts_enabled: true,
-      dependabot_security_updates_enabled: true,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          required_approving_review_count: 1,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
+      description: "Gradle Build customizations for the Technology Compatibility Kits"
     }
   ],
 }

--- a/otterdog/eclipse-dataspacetck.jsonnet
+++ b/otterdog/eclipse-dataspacetck.jsonnet
@@ -39,6 +39,75 @@ orgs.newOrg('eclipse-dataspacetck') {
   _repositories+:: [
     newRepo('cvf') {
       description: "Compliance Verification Framework",
+      has_discussions: true,
+      has_wiki: false,
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      private_vulnerability_reporting_enabled: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
     },
+    newRepo('dcp-tck'){
+      description: "Technology Compatibility Kit for the Decentralized Claims Protocol",
+      has_discussions: true,
+      has_wiki: false,
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      private_vulnerability_reporting_enabled: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
+    },
+    newRepo('tck-common'){
+      description: "Shared code for all Technology Compatibility Kits and other projects",
+      has_discussions: true,
+      has_wiki: false,
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      private_vulnerability_reporting_enabled: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
+    },
+    newRepo('tck-build'){
+      description: "Gradle Build customizations for the Technology Compatibility Kits",
+      has_discussions: true,
+      has_wiki: false,
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      private_vulnerability_reporting_enabled: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
+    }
   ],
 }

--- a/otterdog/eclipse-dataspacetck.jsonnet
+++ b/otterdog/eclipse-dataspacetck.jsonnet
@@ -51,7 +51,7 @@ orgs.newOrg('eclipse-dataspacetck') {
   _repositories+:: [
     newRepo('dsp-tck') {
       aliases: ['cvf'],
-      description: "Compliance Verification Framework",
+      description: "Technology Compatibility Kit for the Dataspace Protocol",
     },
     newRepo('dcp-tck'){
       description: "Technology Compatibility Kit for the Decentralized Claims Protocol"


### PR DESCRIPTION
This PR adds configuration for three more repositories.

Open questions:
- is there a way to provision all repos with the same configuration, something like a default config?
- is there a way to rename a repo, in particular `cvf` should be renamed to `dsp-tck`?

Closes https://github.com/eclipse-dataspacetck/cvf/issues/110

