### PR TITLE
fix: remove branch protection rule

### DIFF
--- a/otterdog/eclipse-dataspacetck.jsonnet
+++ b/otterdog/eclipse-dataspacetck.jsonnet
@@ -22,15 +22,6 @@ local newRepo(repoName) = orgs.newRepo(repoName) {
             deployment_branch_policy: "selected"
         }
       ],
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          allows_force_pushes: true,
-          dismisses_stale_reviews: false,
-          required_approving_review_count: 0,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
 };
 
 orgs.newOrg('eclipse-dataspacetck') {


### PR DESCRIPTION
removes the branch protection rules because:
- in our CI workflow we have a step that makes a commit directly to `main`
- it is sometimes useful to be able to directly push to `main` for maintainers
- only committers have write access anyway, so we don't see much value in additionally protecting `main` at this time 

